### PR TITLE
Ensure apt lists exist for mopidy-* packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN set -exv \
  && curl -sSLf https://apt.mopidy.com/mopidy.gpg \
     | apt-key add - \
  && lazy-apt-repo mopidy https://apt.mopidy.com/mopidy.list \
+ && ensure-apt-lists \
  && lazy-apt --no-install-recommends \
     $(apt-cache search '^mopidy-.*' | sed -e 's/ .*$//' | egrep -v 'gpodder|doc') \
  && :


### PR DESCRIPTION
mopidy-* apt packages are missing from the image, as `apt-cache search` is executing with no apt lists present.